### PR TITLE
feat: recommend gemini and ollama models

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This project demonstrates a simple web-based code editor with live syntax highli
 *   **Simple Interface**: A clean and straightforward code editing experience.
 *   **Dark Theme**: Uses a dark theme for better readability in low-light environments.
 
+## Recommended AI Models
+
+The settings modal now highlights suggested AI models for advanced assistance.
+- Use `gemini-2.5-flash` for a model that can generate code, analyze images, and work with files you provide.
+- For local inference with Ollama, try `qwen2.5-coder`, which supports coding, image understanding, and file inputs.
+
 ## Technologies Used
 
 *   **React**: A JavaScript library for building user interfaces.

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -219,6 +219,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, onSave, 
                         <p className="text-slate-300 mb-2 text-sm">
                           Enter your Google Gemini API key. Your key is stored securely on your local machine.
                         </p>
+                        <p className="text-xs text-slate-400 mb-3">
+                          Recommended model: <code>gemini-2.5-flash</code> (supports coding, images, and file inputs)
+                        </p>
                         <label htmlFor="apiKey" className="text-sm font-medium text-slate-400">Gemini API Key</label>
                         <div className="relative mt-1">
                             <input id="apiKey" type={isKeyVisible ? 'text' : 'password'} value={apiKeyInput} onChange={(e) => setApiKeyInput(e.target.value)} placeholder="Enter your API key here" className="w-full bg-slate-900 border border-slate-600 rounded-md p-3 pr-10 text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition duration-200" autoFocus/>
@@ -231,8 +234,11 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, onSave, 
 
                 {provider === 'ollama' && (
                     <div>
-                         <p className="text-slate-300 mb-2 text-sm">
+                        <p className="text-slate-300 mb-2 text-sm">
                           Configure your local or remote Ollama server. Models will be fetched automatically.
+                        </p>
+                        <p className="text-xs text-slate-400 mb-3">
+                          Recommended model: <code>qwen2.5-coder</code> (supports coding, images, and file inputs)
                         </p>
                         <div className="grid grid-cols-1 gap-4">
                              <div>


### PR DESCRIPTION
## Summary
- highlight `gemini-2.5-flash` as the recommended Gemini model in settings
- highlight `qwen2.5-coder` as the recommended Ollama model in settings
- document the recommended models in README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6898c1e27c8083279b0c4363ebf2b7da