### PR TITLE
feat: add chatgpt provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project demonstrates a simple web-based code editor with live syntax highli
 
 The settings modal now highlights suggested AI models for advanced assistance.
 - Use `gemini-2.5-flash` for a model that can generate code, analyze images, and work with files you provide.
+- Use `gpt-4o-mini` for OpenAI's ChatGPT capabilities, including coding, image understanding, and file inputs.
 - For local inference with Ollama, try `qwen2.5-coder`, which supports coding, image understanding, and file inputs.
 
 ## Recommended AI Model

--- a/components/SettingsModal.tsx
+++ b/components/SettingsModal.tsx
@@ -207,7 +207,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, onSave, 
                 
                 <label className="text-sm font-medium text-slate-400">AI Provider</label>
                 <div className="flex gap-4 mt-2 mb-4 rounded-md bg-slate-900 p-1">
-                    {(['gemini', 'ollama'] as AiProvider[]).map(p => (
+                    {(['gemini', 'chatgpt', 'ollama'] as AiProvider[]).map(p => (
                         <button type="button" key={p} onClick={() => setProvider(p)} className={`flex-1 capitalize text-center text-sm rounded py-1.5 transition-colors ${provider === p ? 'bg-indigo-600 text-white font-semibold' : 'text-slate-300 hover:bg-slate-700'}`}>
                             {p}
                         </button>
@@ -223,6 +223,24 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, onSave, 
                           Recommended model: <code>gemini-2.5-flash</code> (supports coding, images, and file inputs)
                         </p>
                         <label htmlFor="apiKey" className="text-sm font-medium text-slate-400">Gemini API Key</label>
+                        <div className="relative mt-1">
+                            <input id="apiKey" type={isKeyVisible ? 'text' : 'password'} value={apiKeyInput} onChange={(e) => setApiKeyInput(e.target.value)} placeholder="Enter your API key here" className="w-full bg-slate-900 border border-slate-600 rounded-md p-3 pr-10 text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition duration-200" autoFocus/>
+                            <button type="button" onClick={() => setIsKeyVisible(!isKeyVisible)} className="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 hover:text-slate-200" title={isKeyVisible ? 'Hide key' : 'Show key'}>
+                                {isKeyVisible ? <EyeOffIcon className="w-5 h-5" /> : <EyeIcon className="w-5 h-5" />}
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {provider === 'chatgpt' && (
+                    <div>
+                        <p className="text-slate-300 mb-2 text-sm">
+                          Enter your OpenAI API key. Your key is stored securely on your local machine.
+                        </p>
+                        <p className="text-xs text-slate-400 mb-3">
+                          Recommended model: <code>gpt-4o-mini</code> (supports coding, images, and file inputs)
+                        </p>
+                        <label htmlFor="apiKey" className="text-sm font-medium text-slate-400">OpenAI API Key</label>
                         <div className="relative mt-1">
                             <input id="apiKey" type={isKeyVisible ? 'text' : 'password'} value={apiKeyInput} onChange={(e) => setApiKeyInput(e.target.value)} placeholder="Enter your API key here" className="w-full bg-slate-900 border border-slate-600 rounded-md p-3 pr-10 text-slate-200 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition duration-200" autoFocus/>
                             <button type="button" onClick={() => setIsKeyVisible(!isKeyVisible)} className="absolute inset-y-0 right-0 flex items-center px-3 text-slate-400 hover:text-slate-200" title={isKeyVisible ? 'Hide key' : 'Show key'}>

--- a/services/chatgptService.ts
+++ b/services/chatgptService.ts
@@ -1,0 +1,111 @@
+import { Content } from "@google/genai";
+import { CodeFile } from '../types';
+
+interface OpenAIMessage {
+    role: 'system' | 'user' | 'assistant';
+    content: any;
+}
+
+const parseAIResponse = (responseText: string | undefined): { files: CodeFile[]; readmeContent: string } => {
+    if (!responseText) {
+        throw new Error("The AI returned an empty response. Please try again.");
+    }
+
+    let jsonString = responseText.trim();
+
+    const markdownMatch = jsonString.match(/```(json)?\s*(\{[\s\S]*\})\s*```/);
+    if (markdownMatch && markdownMatch[2]) {
+        jsonString = markdownMatch[2];
+    } else {
+        const jsonStart = jsonString.indexOf('{');
+        const jsonEnd = jsonString.lastIndexOf('}');
+        if (jsonStart !== -1 && jsonEnd !== -1 && jsonEnd > jsonStart) {
+            jsonString = jsonString.substring(jsonStart, jsonEnd + 1);
+        }
+    }
+
+    if (!jsonString.startsWith('{') || !jsonString.endsWith('}')) {
+        console.error("Could not find a valid JSON object in the AI response.", "Raw text:", responseText);
+        throw new Error("The AI returned a response that was not valid JSON. Please try again.");
+    }
+
+    try {
+        const parsed = JSON.parse(jsonString);
+        if (Array.isArray(parsed.files) && typeof parsed.readmeContent === 'string') {
+            return parsed;
+        }
+        throw new Error("Parsed JSON does not match the expected structure.");
+    } catch (e) {
+        console.error("AI response parsing error:", e, "Extracted JSON string:", jsonString, "Original raw text:", responseText);
+        throw new Error("The AI returned a response that was not valid JSON. Please try again.");
+    }
+};
+
+const convertToOpenAIMessages = (history: Content[]): OpenAIMessage[] => {
+    return history.map(message => {
+        const role = message.role === 'model' ? 'assistant' : 'user';
+        const content = (message.parts || []).map(part => part.text || '').join('\n');
+        return { role, content };
+    });
+};
+
+export const sendMessage = async (
+    userContent: Content,
+    projectContext: string,
+    history: Content[]
+): Promise<{ files: CodeFile[]; readmeContent: string }> => {
+    if (!window.electronAPI) {
+        throw new Error("Electron API is not available.");
+    }
+
+    const apiKey = await window.electronAPI.getApiKey();
+    if (!apiKey) {
+        throw new Error("API key is not set. Please add it in Settings.");
+    }
+
+    const systemInstruction = `You are a world-class senior software engineer acting as a coding assistant.
+- The user will provide the context of their current project files, followed by their request. You MUST use this context to inform your response.
+- Your response MUST be a single JSON object: { "files": [{ "fileName": "...", "code": "..." }], "readmeContent": "..." }.
+- For each file, "fileName" MUST be the full, relative path including directories.
+- "code" must be the raw, complete code for that file.
+- "readmeContent" must be the full content for a README.md file formatted as markdown.
+- When asked to update, respond with the FULL updated code for ALL relevant files and an updated readmeContent in the same JSON format.`;
+
+    const messages: OpenAIMessage[] = [
+        { role: 'system', content: systemInstruction },
+        ...convertToOpenAIMessages(history)
+    ];
+
+    const promptText = userContent.parts?.find(p => p.text)?.text || '';
+    const imageBase64 = userContent.parts?.find(p => p.inlineData)?.inlineData?.data;
+
+    const userMessageContent: any[] = [{ type: 'text', text: `${projectContext}USER REQUEST: ${promptText}` }];
+    if (imageBase64) {
+        userMessageContent.push({ type: 'image_url', image_url: `data:image/png;base64,${imageBase64}` });
+    }
+    messages.push({ role: 'user', content: userMessageContent });
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+            model: 'gpt-4o-mini',
+            messages,
+            response_format: { type: 'json_object' }
+        })
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+        const errorMessage = data?.error?.message || 'ChatGPT API request failed.';
+        throw new Error(errorMessage);
+    }
+
+    const responseText = data.choices?.[0]?.message?.content;
+    const parsed = parseAIResponse(responseText);
+    return parsed;
+};
+

--- a/types.ts
+++ b/types.ts
@@ -36,7 +36,7 @@ export interface FolderNode {
 export type TreeNode = FileNode | FolderNode;
 
 // --- AI Provider Types ---
-export type AiProvider = 'gemini' | 'ollama';
+export type AiProvider = 'gemini' | 'chatgpt' | 'ollama';
 
 export interface OllamaConfig {
   url: string;


### PR DESCRIPTION
## Summary
- add ChatGPT service using OpenAI API
- enable selecting ChatGPT in settings with API key support
- extend types and app logic to handle ChatGPT responses

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6898e5364728832786fcd1813bddc14e