### PR TITLE
feat: finalize core functionality

### DIFF
--- a/services/chatgptService.ts
+++ b/services/chatgptService.ts
@@ -111,3 +111,31 @@ if (!apiKey) {
     return parsed;
 };
 
+// Convenience function used by the React app. Builds a project context
+// string from the provided files and forwards the request to `sendMessage`.
+export const generateCode = async ({
+  system,
+  prompt,
+  files,
+  imageDataUrl,
+}: {
+  system: string;
+  prompt: string;
+  files: CodeFile[];
+  imageDataUrl?: string;
+}): Promise<{ files: CodeFile[]; readmeContent: string }> => {
+  const history: Content[] = [];
+  const projectContext = files
+    .map((f) => `File: ${f.fileName}\n${f.code}`)
+    .join('\n\n');
+
+  const parts: any[] = [{ text: `${system}\n\n${projectContext}\n\nUSER REQUEST:\n${prompt}` }];
+  if (imageDataUrl) {
+    const base64 = imageDataUrl.split(',')[1] || imageDataUrl;
+    parts.push({ inlineData: { data: base64 } });
+  }
+
+  const content: Content = { role: 'user', parts };
+  return await sendMessage(content, projectContext, history);
+};
+

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -146,3 +146,36 @@ export const getChatHistory = async (): Promise<Content[] | null> => {
 export const endChatSession = () => {
   chat = null;
 };
+
+// Wrapper used by the React app to generate code using Gemini.
+export const generateCode = async ({
+  system,
+  prompt,
+  files,
+  imageDataUrl,
+}: {
+  system: string;
+  prompt: string;
+  files: CodeFile[];
+  imageDataUrl?: string;
+}): Promise<{ files: CodeFile[]; readmeContent: string }> => {
+  await initializeChat();
+
+  const projectContext = files
+    .map((f) => `File: ${f.fileName}\n${f.code}`)
+    .join('\n\n');
+
+  const parts: any[] = [
+    {
+      text: `${system}\n\n${projectContext}\n\nUSER REQUEST:\n${prompt}`,
+    },
+  ];
+
+  if (imageDataUrl) {
+    const base64 = imageDataUrl.split(',')[1] || imageDataUrl;
+    parts.push({ inlineData: { data: base64 } });
+  }
+
+  const content: Content = { role: 'user', parts };
+  return await sendMessage(content);
+};

--- a/services/ollamaService.ts
+++ b/services/ollamaService.ts
@@ -88,3 +88,31 @@ export const sendMessage = async (
     console.log("[AI] Parsed Ollama response:", parsed);
     return parsed;
 };
+
+// Wrapper for the React app to generate code via the local Ollama backend.
+export const generateCode = async ({
+  system,
+  prompt,
+  files,
+  imageDataUrl,
+}: {
+  system: string;
+  prompt: string;
+  files: CodeFile[];
+  imageDataUrl?: string;
+}): Promise<{ files: CodeFile[]; readmeContent: string }> => {
+  const history: Content[] = [];
+  const projectContext = files
+    .map((f) => `File: ${f.fileName}\n${f.code}`)
+    .join('\n\n');
+
+  const parts: any[] = [{ text: `${system}\n\n${projectContext}\n\nUSER REQUEST:\n${prompt}` }];
+  if (imageDataUrl) {
+    const base64 = imageDataUrl.split(',')[1] || imageDataUrl;
+    parts.push({ inlineData: { data: base64 } });
+  }
+  const content: Content = { role: 'user', parts };
+
+  const config = await window.electronAPI.getOllamaConfig?.();
+  return await sendMessage(content, projectContext, history, config);
+};


### PR DESCRIPTION
## Summary
- implement CodeDisplay with file tabs and editing
- add generateCode wrappers for Gemini, ChatGPT, and Ollama services
- clamp active tab index when files are removed and tidy service wrappers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run dev` *(fails: error while loading shared libraries: libatk-1.0.so.0)*
- `npm start` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68acdc3306d08327b8d930a69620e878